### PR TITLE
Fix 502 issue on CGI buffer

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -15,6 +15,8 @@ location YNH_WWW_PATH {
     fastcgi_param   PATH_INFO       $fastcgi_path_info;
     fastcgi_param   SCRIPT_FILENAME $request_filename;
     fastcgi_read_timeout 600;
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k; 
   }
 
   # Include SSOWAT user panel.


### PR DESCRIPTION
Complete error message was:

`upstream sent too big header while reading response header from upstream`

This increases the buffer size.

*Note: It is also possible to disable the buffering but not tested*