### PR TITLE
Fix stretch compatibility by creating and using a dedicated MySQL admin user (fixes #71)

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -28,8 +28,8 @@ $i = 0;
 $i++;
 /* Authentication type */
 $cfg['Servers'][$i]['auth_type'] = 'config';
-$cfg['Servers'][$i]['user'] = 'root';
-$cfg['Servers'][$i]['password'] = 'YNH_MYSQL_ROOT_PASSWORD';
+$cfg['Servers'][$i]['user'] = 'YNH_PMA_ADMIN_USER';
+$cfg['Servers'][$i]['password'] = 'YNH_PMA_ADMIN_PASSWORD';
 /* Server parameters */
 /*
 $cfg['Servers'][$i]['host'] = 'localhost';

--- a/scripts/backup
+++ b/scripts/backup
@@ -22,6 +22,13 @@ set -eu
 source /usr/share/yunohost/helpers
 
 #=================================================
+# MANAGE SCRIPT FAILURE
+#=================================================
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
+
+#=================================================
 # LOAD SETTINGS
 #=================================================
 

--- a/scripts/install
+++ b/scripts/install
@@ -59,6 +59,17 @@ db_name=$(ynh_sanitize_dbid $app)
 ynh_app_setting_set $app db_name $db_name
 ynh_mysql_setup_db $db_name $db_name
 
+# Setup a privileged user for phpmyadmin (to prevent using MySQL root user)
+db_admin_user="${app}_root"
+ynh_app_setting_set $app db_admin_user $db_admin_user
+db_admin_pwd="$(ynh_string_random)"
+ynh_app_setting_set $app db_admin_pwd $db_admin_pwd
+
+if ! ynh_mysql_user_exists "$db_admin_user" ; then
+  ynh_mysql_create_user "$db_admin_user" "$db_admin_pwd"
+  ynh_mysql_execute_as_root "GRANT ALL PRIVILEGES ON *.* TO '$db_admin_user'@'localhost' IDENTIFIED BY '$db_admin_pwd' WITH GRANT OPTION;
+  FLUSH PRIVILEGES;" mysql
+fi
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
@@ -106,6 +117,8 @@ ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_name" \
 #=================================================
 
 ynh_replace_string "YNH_DOMAIN" "$domain" ../conf/config.inc.php
+ynh_replace_string "YNH_PMA_ADMIN_USER" "$db_admin_user" ../conf/config.inc.php
+ynh_replace_string "YNH_PMA_ADMIN_PASSWORD" "$db_admin_pwd" ../conf/config.inc.php
 ynh_replace_string "YNH_PMA_USER" "$db_name" ../conf/config.inc.php
 ynh_replace_string "YNH_PMA_PASSWORD" "$db_pwd" ../conf/config.inc.php
 ynh_replace_string "YNH_MYSQL_ROOT_PASSWORD" "$(cat $MYSQL_ROOT_PWD_FILE)" ../conf/config.inc.php

--- a/scripts/remove
+++ b/scripts/remove
@@ -18,6 +18,7 @@ app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get $app domain)
 db_name=$(ynh_app_setting_get $app db_name)
 final_path=$(ynh_app_setting_get $app final_path)
+db_admin_user=$(ynh_app_setting_get $app db_admin_user)
 
 #=================================================
 # STANDARD REMOVE
@@ -27,6 +28,9 @@ final_path=$(ynh_app_setting_get $app final_path)
 
 # Remove a database if it exists, along with the associated user
 ynh_mysql_remove_db $db_name $db_name
+
+# Remove phpmyadmin MySQL admin user
+ynh_mysql_drop_user $db_admin_user
 
 #=================================================
 # REMOVE APP MAIN DIR

--- a/scripts/restore
+++ b/scripts/restore
@@ -22,6 +22,13 @@ set -eu
 source /usr/share/yunohost/helpers
 
 #=================================================
+# MANAGE SCRIPT FAILURE
+#=================================================
+
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
+
+#=================================================
 # LOAD SETTINGS
 #=================================================
 
@@ -64,6 +71,15 @@ db_pwd=$(ynh_app_setting_get $app mysqlpwd)
 ynh_mysql_setup_db $db_name $db_name $db_pwd
 ynh_mysql_connect_as $db_name $db_pwd $db_name < ./db.sql
 
+# Setup a privileged user for phpmyadmin (to prevent using MySQL root user)
+db_admin_user=$(ynh_app_setting_get $app db_admin_user)
+db_admin_pwd=$(ynh_app_setting_get $app db_admin_pwd)
+
+if ! ynh_mysql_user_exists "$db_admin_user" ; then
+  ynh_mysql_create_user "$db_admin_user" "$db_admin_pwd"
+  ynh_mysql_execute_as_root "GRANT ALL PRIVILEGES ON *.* TO '$db_admin_user'@'localhost' IDENTIFIED BY '$db_admin_pwd' WITH GRANT OPTION;
+  FLUSH PRIVILEGES;" mysql
+fi
 #=================================================
 # RECREATE THE DEDICATED USER
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,6 +20,8 @@ path_url=$(ynh_app_setting_get $app path)
 admin=$(ynh_app_setting_get $app admin)
 final_path=$(ynh_app_setting_get $app final_path)
 db_name=$(ynh_app_setting_get $app db_name)
+db_admin_user=$(ynh_app_setting_get $app db_admin_user)
+db_admin_pwd=$(ynh_app_setting_get $app db_admin_pwd)
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -43,6 +45,21 @@ if [ -z $admin ]; then
 	admin=$(ynh_app_setting_get $app admin_user)
 	ynh_app_setting_set "$app" admin "$admin"
 	ynh_app_setting_delete $app admin_user
+fi
+
+# If db_admin_user doesn't exist, create it
+if [ -z $db_admin_user ]; then
+	# Setup a privileged user for phpmyadmin (to prevent using MySQL root user)
+	db_admin_user="${app}_root"
+	ynh_app_setting_set $app db_admin_user $db_admin_user
+	db_admin_pwd="$(ynh_string_random)"
+	ynh_app_setting_set $app db_admin_pwd $db_admin_pwd
+
+	if ! ynh_mysql_user_exists "$db_admin_user" ; then
+	  ynh_mysql_create_user "$db_admin_user" "$db_admin_pwd"
+	  ynh_mysql_execute_as_root "GRANT ALL PRIVILEGES ON *.* TO '$db_admin_user'@'localhost' IDENTIFIED BY '$db_admin_pwd' WITH GRANT OPTION;
+	  FLUSH PRIVILEGES;" mysql
+	fi
 fi
 
 #=================================================
@@ -122,6 +139,8 @@ ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_name" \
 ynh_backup_if_checksum_is_different "$final_path/config.inc.php"
 
 ynh_replace_string "YNH_DOMAIN" "$domain" ../conf/config.inc.php
+ynh_replace_string "YNH_PMA_ADMIN_USER" "$db_admin_user" ../conf/config.inc.php
+ynh_replace_string "YNH_PMA_ADMIN_PASSWORD" "$db_admin_pwd" ../conf/config.inc.php
 ynh_replace_string "YNH_PMA_USER" "$db_name" ../conf/config.inc.php
 ynh_replace_string "YNH_PMA_PASSWORD" "$db_pwd" ../conf/config.inc.php
 ynh_replace_string "YNH_MYSQL_ROOT_PASSWORD" "$(cat $MYSQL_ROOT_PWD_FILE)" ../conf/config.inc.php


### PR DESCRIPTION
## Problem
- *phpMyAdmin doesn't work on Stretch (access denied to MySQL root user)*

## Solution
- MySQL root access in Stretch is limited to socket access via the root system user (see [here](https://stackoverflow.com/questions/39281594/error-1698-28000-access-denied-for-user-rootlocalhost/42742610#42742610))
In order to be compatible with Stretch and Jessie, use another privileged account than root.
- add missing ynh_abort_if_errors by the way :wink: 

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/phpmyadmin_ynh%20fix_stretch_compatibility%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/phpmyadmin_ynh%20fix_stretch_compatibility%20(Official)/)

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
