### PR TITLE
Upgrade to upstream version 5.0.2 / Use PHP 7.3

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://files.phpmyadmin.net/phpMyAdmin/4.9.5/phpMyAdmin-4.9.5-all-languages.tar.gz
-SOURCE_SUM=d1ab98cde370c39dafdaa13ce02fa35cecaaa6d33553fde092604b99660e8835
+SOURCE_URL=https://files.phpmyadmin.net/phpMyAdmin/5.0.2/phpMyAdmin-5.0.2-all-languages.tar.gz
+SOURCE_SUM=8d5cb67de154262b6e51e6ac6967d0931d28ef39cdc7fbec44011d374eb432ae
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,7 +16,7 @@ location __PATH__/ {
   try_files $uri $uri/ index.php;
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-    fastcgi_pass unix:/var/run/php/php7.0-fpm-__NAME__.sock;
+    fastcgi_pass unix:/var/run/php/php__PHPVERSION__-fpm-__NAME__.sock;
     fastcgi_index index.php;
     include fastcgi_params;
     fastcgi_param   REMOTE_USER     $remote_user;

--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -33,7 +33,7 @@ group = __USER__
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /var/run/php/php7.0-fpm-__NAMETOCHANGE__.sock
+listen = /var/run/php/php__PHPVERSION__-fpm-__NAMETOCHANGE__.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Manage MySQL databases over the web",
         "fr": "Application web de gestion des bases de données MySQL"
     },
-    "version": "4.9.5~ynh1",
+    "version": "5.0.2~ynh1",
     "url": "http://www.phpmyadmin.net",
     "license": "GPL-2.0-only",
     "maintainer": {
@@ -14,7 +14,7 @@
         "email": "julien.malik@paraiso.me"
     },
     "requirements": {
-        "yunohost": ">= 3.5.0"
+        "yunohost": ">= 3.8.1"
     },
     "multi_instance": false,
     "services": [

--- a/scripts/backup
+++ b/scripts/backup
@@ -6,7 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# source ../settings/scripts/_common.sh
+source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -48,7 +48,7 @@ ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 ynh_script_progression --message="Backing up php-fpm configuration..."
 
-ynh_backup --src_path="/etc/php/7.0/fpm/pool.d/$app.conf"
+ynh_backup --src_path="/etc/php/$YNH_PHP_VERSION/fpm/pool.d/$app.conf"
 
 #=================================================
 # BACKUP THE MYSQL DATABASE

--- a/scripts/install
+++ b/scripts/install
@@ -101,7 +101,7 @@ ynh_system_user_create --username=$app
 ynh_script_progression --message="Configuring php-fpm..." --weight=2
 
 # Create a dedicated php-fpm config
-ynh_add_fpm_config
+ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
 
 #=================================================
 # SPECIFIC SETUP

--- a/scripts/restore
+++ b/scripts/restore
@@ -6,7 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# source ../settings/scripts/_common.sh
+source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -95,16 +95,21 @@ chown $app: $final_path/tmp
 # RESTORE THE PHP-FPM CONFIGURATION
 #=================================================
 
-ynh_restore_file --origin_path="/etc/php/7.0/fpm/pool.d/$app.conf"
+ynh_script_progression --message="Reconfiguring php-fpm..." --weight=6
+
+# Restore the file first, so it can have a backup if different
+ynh_restore_file --origin_path="/etc/php/$YNH_PHP_VERSION/fpm/pool.d/$app.conf"
+
+# Recreate a dedicated php-fpm config
+ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
 
 #=================================================
 # GENERIC FINALIZATION
 #=================================================
 # RELOAD NGINX AND PHP-FPM
 #=================================================
-ynh_script_progression --message="Reloading nginx web server and php-fpm..."
+ynh_script_progression --message="Reloading nginx web server..."
 
-ynh_systemd_action --service_name=php7.0-fpm --action=reload
 ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -128,7 +128,7 @@ ynh_system_user_create --username=$app
 ynh_script_progression --message="Upgrading php-fpm configuration..." --weight=4
 
 # Create a dedicated php-fpm config
-ynh_add_fpm_config
+ynh_add_fpm_config --phpversion="$YNH_PHP_VERSION" --package="$extra_php_dependencies"
 
 #=================================================
 # SPECIFIC UPGRADE
@@ -177,22 +177,6 @@ cp ../conf/config.inc.php $final_path
 ynh_store_file_checksum --file="$final_path/config.inc.php"
 
 #=================================================
-# INSTALL DEPENDENCIES
-#=================================================
-
-if [ "$upgrade_type" == "UPGRADE_APP" ]
-then
-	
-	ynh_script_progression --message="Upgrading dependencies with Composer..." --weight=19
-
-	# Install composer
-	ynh_install_composer
-
-	# Install dependencies
-	ynh_exec_warn_less ynh_composer_exec --commands=\"update --no-dev\"
-fi
-
-#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # SECURE FILES AND DIRECTORIES
@@ -206,6 +190,22 @@ chmod 640 $final_path/config.inc.php
 # Setup phpMyAdmin temporary folder
 mkdir -p $final_path/tmp
 chown -R $app: $final_path/tmp
+
+
+#=================================================
+# INSTALL DEPENDENCIES
+#=================================================
+
+if [ "$upgrade_type" == "UPGRADE_APP" ]
+then
+	
+	ynh_script_progression --message="Upgrading dependencies with Composer..." --weight=19
+
+	# Force dependency to the used PHP version
+	ynh_exec_warn_less ynh_composer_exec --commands=\"config -g platform.php $YNH_PHP_VERSION\"
+	# Install dependencies
+	ynh_exec_warn_less ynh_composer_exec --commands=\"update --no-dev\"
+fi
 
 #=================================================
 # SETUP SSOWAT


### PR DESCRIPTION
## Problem
- *The application is not up-to-date with the upstream*
- *upstream versions require PHP 7.3*

## Solution
- *Upgrade to latest upstream version 5.0.2*
- *Use latest PHP helpers from YunoHost 3.8 to use PHP 7.3*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : yalh76
- [x] **Approval (LGTM)** : yalh76
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/phpmyadmin_ynh%20PR102/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/phpmyadmin_ynh%20PR102/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/phpmyadmin_ynh%20PR102%20(ericgaspar)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/phpmyadmin_ynh%20PR102%20(ericgaspar)/)  